### PR TITLE
range filters

### DIFF
--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -418,5 +418,59 @@ input[type=range].parade:focus::-ms-fill-upper {
 }
 
 .parade_filter_controls {
+  position: relative;
+  min-width: 350px;
   float: left;
+}
+
+/* styles from http://stackoverflow.com/questions/4753946/html5-form-slider-with-two-inputs-possible */
+.parade_filter_controls input[type=range] {
+  pointer-events: none;
+  position: absolute;
+  right: 45px;
+  overflow: hidden;
+  width: 150px;
+  outline: none;
+  margin: 0;
+  padding: 0;
+}
+.parade_filter_controls input::-webkit-slider-thumb {
+  pointer-events: all;
+  position: relative;
+  z-index: 1;
+  outline: 0;
+}
+.parade_filter_controls input::-moz-range-thumb {
+  pointer-events: all;
+  position: relative;
+  z-index: 10;
+  -moz-appearance: none;
+  width: 9px;
+}
+.parade_filter_controls input::-moz-range-track {
+  position: relative;
+  z-index: -1;
+  background-color: rgba(0, 0, 0, 1);
+  border: 0;
+}
+.parade_filter_controls input:last-of-type::-moz-range-track {
+  -moz-appearance: none;
+  background: none transparent;
+  border: 0;
+}
+.parade_filter_controls input[type=range]::-moz-focus-outer {
+  border: 0;
+}
+
+/* parade_filterinput_max is generated for FilterInput named 'max' */
+.parade_filterinput_min span {
+  position: absolute;
+  right: 200px;
+  top: 5px;
+}
+
+.parade_filterinput_max span {
+  position: absolute;
+  right: 10px;
+  top: 5px;
 }

--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -94,6 +94,11 @@ ul {
   margin-left: 5px;
 }
 
+.filterContainer input[type='range'] {
+  position: relative;
+  top: 4px;
+}
+
 .plateGrid, .centrePanel {
   flex: 1;
   width: 100%;

--- a/src/js/filter/FilterContainer.js
+++ b/src/js/filter/FilterContainer.js
@@ -82,6 +82,7 @@ class FilterContainer extends React.Component {
                         <ParadeFilter
                             key={fname + idx}
                             filterIndex={idx}
+                            filterValues={this.props.filterValues[idx]}
                             name={fname}
                             parentType={this.props.parentType}
                             parentId={this.props.parentId}

--- a/src/js/filter/FilterHub.js
+++ b/src/js/filter/FilterHub.js
@@ -49,18 +49,26 @@ class FilterHub extends React.Component {
         this.filterFunctions[filterIndex] = filterFunc;
         let filterValues = [...this.state.filterValues];    // new list
         filterValues[filterIndex] = defaultValues;
+        console.log('handleFilterLoaded', filterValues);
         this.setState({
             filterValues: filterValues,
         });
     }
 
     handleFilterChange(filterIndex, paramName, paramValue) {
-        let newValues = Object.assign({}, this.state.filterValues[filterIndex]);
-        newValues[paramName] = paramValue;
-        let filterValues = [...this.state.filterValues];    // new list
-        filterValues[filterIndex] = newValues;
-        this.setState({
-            filterValues: filterValues
+        // A parameter has changed in one of the list of filters...
+        this.setState(prevState => {
+            // Copy the previous set of values for the filter at this index...
+            let newValues = Object.assign({}, prevState.filterValues[filterIndex]);
+            // Assign the new value...
+            newValues[paramName] = paramValue;
+            // Make a copy of the previous list of parameter values
+            let filterValues = [...prevState.filterValues];
+            // And add back the new object to the correct index
+            filterValues[filterIndex] = newValues;
+            return {
+                filterValues: filterValues
+            }
         });
     }
 

--- a/src/js/filter/FilterInput.js
+++ b/src/js/filter/FilterInput.js
@@ -51,14 +51,16 @@ class FilterInput extends React.Component {
             )
         }
         if (this.props.min != undefined && this.props.max != undefined) {
+            // show range slider from min-1 to max+1
             return (
-                <span>
+                <span className={"parade_filterinput_" + param.name}>
                     <span> {this.props.value}</span>
                     <input
                         name={param.name}
                         type='range'
-                        min={this.props.min}
-                        max={this.props.max}
+                        value={this.props.value}
+                        min={this.props.min - 1}
+                        max={this.props.max + 1}
                         onChange={onChange}
                         title={param.title ? param.title : ''}
                     />

--- a/src/js/filter/FilterInput.js
+++ b/src/js/filter/FilterInput.js
@@ -50,10 +50,16 @@ class FilterInput extends React.Component {
                 </select>
             )
         }
+        let type = param.type;
+        if (this.props.min != undefined && this.props.max != undefined) {
+            type = 'range';
+        }
         return (
             <input
                 name={param.name}
-                type={param.type}
+                type={type}
+                min={this.props.min}
+                max={this.props.max}
                 onChange={onChange}
                 title={param.title ? param.title : ''}
             />

--- a/src/js/filter/FilterInput.js
+++ b/src/js/filter/FilterInput.js
@@ -50,14 +50,25 @@ class FilterInput extends React.Component {
                 </select>
             )
         }
-        let type = param.type;
         if (this.props.min != undefined && this.props.max != undefined) {
-            type = 'range';
+            return (
+                <span>
+                    <span> {this.props.value}</span>
+                    <input
+                        name={param.name}
+                        type='range'
+                        min={this.props.min}
+                        max={this.props.max}
+                        onChange={onChange}
+                        title={param.title ? param.title : ''}
+                    />
+                </span>
+            )
         }
         return (
             <input
                 name={param.name}
-                type={type}
+                type={param.type}
                 min={this.props.min}
                 max={this.props.max}
                 onChange={onChange}

--- a/src/js/filter/ParadeFilter.js
+++ b/src/js/filter/ParadeFilter.js
@@ -101,6 +101,7 @@ class ParadeFilter extends React.Component {
                                 max={this.state.maximum}
                                 key={p.name}
                                 onChange={this.handleFilterInput}
+                                value={this.props.filterValues[p.name]}
                             />
                 })}
                 </div>

--- a/src/js/filter/ParadeFilter.js
+++ b/src/js/filter/ParadeFilter.js
@@ -87,6 +87,9 @@ class ParadeFilter extends React.Component {
                 maximum: filterParam.maxima[value]
             });
         }
+        // set new filter value for this column
+        this.props.handleFilterChange(this.props.filterIndex,
+                                      'count', filterParam.minima[value]);
     }
 
     render() {

--- a/src/js/filter/ParadeFilter.js
+++ b/src/js/filter/ParadeFilter.js
@@ -97,6 +97,8 @@ class ParadeFilter extends React.Component {
                 {this.state.filterParams.map(p => {
                     return <FilterInput
                                 param={p}
+                                min={this.state.minimum}
+                                max={this.state.maximum}
                                 key={p.name}
                                 onChange={this.handleFilterInput}
                             />

--- a/src/js/filter/ParadeFilter.js
+++ b/src/js/filter/ParadeFilter.js
@@ -87,11 +87,11 @@ class ParadeFilter extends React.Component {
                 maximum: filterParam.maxima[value]
             });
         }
-        // set new filter value for this column
+        // set new filter values for this column, +/- 1 so we don't filter any
         this.props.handleFilterChange(this.props.filterIndex,
-                                      'min', filterParam.minima[value]);
+                                      'min', filterParam.minima[value] - 1);
         this.props.handleFilterChange(this.props.filterIndex,
-                                      'max', filterParam.maxima[value]);
+                                      'max', filterParam.maxima[value] + 1);
     }
 
     render() {

--- a/src/js/filter/ParadeFilter.js
+++ b/src/js/filter/ParadeFilter.js
@@ -89,7 +89,9 @@ class ParadeFilter extends React.Component {
         }
         // set new filter value for this column
         this.props.handleFilterChange(this.props.filterIndex,
-                                      'count', filterParam.minima[value]);
+                                      'min', filterParam.minima[value]);
+        this.props.handleFilterChange(this.props.filterIndex,
+                                      'max', filterParam.maxima[value]);
     }
 
     render() {

--- a/table_filters/omero_filters.py
+++ b/table_filters/omero_filters.py
@@ -88,7 +88,9 @@ def get_script(request, script_name, conn):
         # e.g. {'type': 'Image', 'id': 1}
         # and should return true or false
         f = """(function filter(data, params) {
-            if (isNaN(params.count) || params.count == '') return true;
+            var min_value = parseInt(params.min);
+            var max_value = parseInt(params.max);
+            if (isNaN(min_value) && isNaN(max_value)) return true;
             var table_data = %s;
             if (data.wellId) {
                 var rowIndex = table_data.Well.indexOf(data.wellId);
@@ -96,9 +98,9 @@ def get_script(request, script_name, conn):
                 var rowIndex = table_data.Image.indexOf(data.id);
             }
             var value = table_data[params.column_name][rowIndex];
-            if (params.operator === '=') return value == params.count;
-            if (params.operator === '<') return value < params.count;
-            if (params.operator === '>') return value > params.count;
+            if (isNaN(min_value)) return (value < max_value);
+            if (isNaN(max_value)) return (value > min_value);
+            return (value > min_value && value < max_value);
         })
         """ % json.dumps(table_data)
 
@@ -109,11 +111,10 @@ def get_script(request, script_name, conn):
                           'minima': minima,
                           'maxima': maxima,
                           'histograms': histograms},
-                         {'name': 'operator',
-                          'type': 'text',
-                          'values': ['>', '=', '<'],
-                          'default': '>'},
-                         {'name': 'count',
+                         {'name': 'min',
+                          'type': 'number',
+                          'default': ''},
+                         {'name': 'max',
                           'type': 'number',
                           'default': ''}]
         return JsonResponse(


### PR DESCRIPTION
If we have a min and max values, it's kinda nice to show a range slider.
The interaction gives good feedback since the default behaviour is to filter as you slide. However, *if* the performance of filtering was slow (lots of data) we could consider only filtering when the slider handle is released (or at least add a "debounce" so we wait a tiny bit before filtering).

<img width="417" alt="screen shot 2018-04-07 at 06 29 11" src="https://user-images.githubusercontent.com/900055/38451726-0eff7a4e-3a2d-11e8-96b3-99395cc28858.png">
